### PR TITLE
added bibtex settings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,4 +217,8 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None)
-    }
+}
+
+# -- BibTeX Setting  ----------------------------------------------
+
+bibtex_bibfiles = ['refs.bib', 'my_ref.bib']


### PR DESCRIPTION
The latest version of `sphinxcontrib.bibtex` requires specifying `bibtex_bibfiles`.